### PR TITLE
Update license information in recipe.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pillow-heif-fee
 
 Home: https://github.com/bigcat88/pillow_heif
 
-Package license: GPL-2.0-or-later AND EPL-2.0 AND BSD-3-Clause
+Package license: BSD-3-Clause
 
 Summary: Python interface for libheif library
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -58,7 +58,7 @@ about:
   homepage: https://github.com/bigcat88/pillow_heif
   repository: https://github.com/bigcat88/pillow_heif
   summary: Python interface for libheif library
-  license: GPL-2.0-or-later AND EPL-2.0 AND BSD-3-Clause
+  license: BSD-3-Clause
   license_file:
     - LICENSE.txt
     - tests/images/heif_other/nokia/COPYRIGHT.txt

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,7 +17,11 @@ build:
   skip:
     - match(python, "<3.9")
   script:
+    - if: win
+      then: if not exist "%LIBRARY_LIB%\libheif.lib" copy "%LIBRARY_LIB%\heif.lib" "%LIBRARY_LIB%\libheif.lib"
     - python -m pip install . -vv --no-deps --no-build-isolation
+    - if: win
+      then: if exist "%LIBRARY_LIB%\libheif.lib" del "%LIBRARY_LIB%\libheif.lib"
 
 requirements:
   build:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,8 +17,6 @@ build:
   skip:
     - match(python, "<3.9")
   script:
-    - if: win
-      then: if not exist "%LIBRARY_LIB%\libheif.lib" copy "%LIBRARY_LIB%\heif.lib" "%LIBRARY_LIB%\libheif.lib"
     - python -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: af8d2bda85e395677d5bb50d7bda3b5655c946cc95b913b5e7222fabacbb467f
 
 build:
-  number: 1
+  number: 2
   skip:
     - match(python, "<3.9")
   script:


### PR DESCRIPTION
If `pillow_heif` doesn't statically link `libheif` nor `x265`, it should remain BSD-3 only. This gives much more flexibility from a licensing prespective, since the `libheif` dependency allows to choose what to include (GPL or not, see [here](https://github.com/conda-forge/libheif-feedstock/blob/f3f3f52963002ff65e25c5f7ed00890e06dc114a/recipe/meta.yaml#L39)).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
